### PR TITLE
Add Fixnum#percentage_off, Float#percentage_off, BigDecimal#percentage_off

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ gem install 'finishing_moves'
 - [`Hash#delete_each`](#hashdelete_each)
 - [`Hash#delete_each!`](#hashdelete_each-1)
 - [`Integer#length`](#integerlength)
+- [`Fixnum#subtract_percent`](#fixnumsubtract_percent)
 - [`Boolean` Typecasting](#typecasting-to-boolean)
 
 ###### *New in 0.3.0!*
@@ -576,6 +577,21 @@ For consistency, we added matching methods to `Float` and `BigDecimal` that simp
 ##### Alias
 
 `length` is aliased to `digits` for alternative clarity.
+
+### `Fixnum#subtract_percent`
+
+Ruby does not provide a nice method to subtract a percentage from a Fixnum. This works on an Integer, Float and BigDecimal.
+
+```ruby
+50.subtract_percent(10)
+# => 45.0
+
+1.0.subtract_percent(10)
+# => 0.9
+
+12654377184.123123.subtract_percent(10)
+# => 11388939465.710812
+```
 
 ### Typecasting *to* `Boolean`
 

--- a/lib/finishing_moves/fixnum.rb
+++ b/lib/finishing_moves/fixnum.rb
@@ -4,7 +4,7 @@ class Integer
   end
   alias_method :digits, :length
   
-  def percentage_off(percent)
+  def subtract_percent(percent)
     self * ((100.0 - percent.to_f)/100.0)
   end
 end
@@ -15,7 +15,7 @@ class Float
   end
   alias_method :digits, :length
   
-  def percentage_off(percent)
+  def subtract_percent(percent)
     self * ((100.0 - percent.to_f)/100.0)
   end
 end
@@ -26,7 +26,7 @@ class BigDecimal
   end
   alias_method :digits, :length
   
-  def percentage_off(percent)
+  def subtract_percent(percent)
     self * ((100.0 - percent.to_f)/100.0)
   end
 end

--- a/lib/finishing_moves/fixnum.rb
+++ b/lib/finishing_moves/fixnum.rb
@@ -3,6 +3,10 @@ class Integer
     Math.log10(self.abs).to_i + 1
   end
   alias_method :digits, :length
+  
+  def percentage_off(percent)
+    self * ((100.0 - percent.to_f)/100.0)
+  end
 end
 
 class Float
@@ -10,6 +14,10 @@ class Float
     raise ArgumentError.new("Cannot get length: \"#{self}\" is not an integer")
   end
   alias_method :digits, :length
+  
+  def percentage_off(percent)
+    self * ((100.0 - percent.to_f)/100.0)
+  end
 end
 
 class BigDecimal
@@ -17,4 +25,8 @@ class BigDecimal
     raise ArgumentError.new("Cannot get length: \"#{self}\" is not an integer")
   end
   alias_method :digits, :length
+  
+  def percentage_off(percent)
+    self * ((100.0 - percent.to_f)/100.0)
+  end
 end

--- a/spec/fixnum_spec.rb
+++ b/spec/fixnum_spec.rb
@@ -39,5 +39,24 @@ describe "Count number length" do
     # alias
     expect{ -0.9999999999999062.digits }.to raise_error(ArgumentError)
   end
+  
+  it "Fixnum#percentage_off" do
+    expect(1.percentage_off(10)).to eq 0.9
+    expect(10.percentage_off(10)).to eq 9.0
+    expect(25.percentage_off(5)).to eq 23.75
+    expect(76.percentage_off(40)).to eq 45.6
+  end
+  
+  it "Bignum#percentage_off" do
+    expect(1.0.percentage_off(10)).to eq 0.9
+    expect(10.4.percentage_off(10)).to eq 9.360000000000001
+    expect(25.2.percentage_off(5)).to eq 23.939999999999998
+    expect(76.6.percentage_off(40)).to eq 45.959999999999994
+  end
+  
+  it "BigDecimal#percentage_off" do
+    expect(12654377184.123123.percentage_off(10)).to eq 11388939465.710812
+    expect(123.129405.percentage_off(25)).to eq 92.34705375
+  end
 
 end

--- a/spec/fixnum_spec.rb
+++ b/spec/fixnum_spec.rb
@@ -40,23 +40,23 @@ describe "Count number length" do
     expect{ -0.9999999999999062.digits }.to raise_error(ArgumentError)
   end
   
-  it "Fixnum#percentage_off" do
-    expect(1.percentage_off(10)).to eq 0.9
-    expect(10.percentage_off(10)).to eq 9.0
-    expect(25.percentage_off(5)).to eq 23.75
-    expect(76.percentage_off(40)).to eq 45.6
+  it "Fixnum#subtract_percent" do
+    expect(1.subtract_percent(10)).to eq 0.9
+    expect(10.subtract_percent(10)).to eq 9.0
+    expect(25.subtract_percent(5)).to eq 23.75
+    expect(76.subtract_percent(40)).to eq 45.6
   end
   
-  it "Bignum#percentage_off" do
-    expect(1.0.percentage_off(10)).to eq 0.9
-    expect(10.4.percentage_off(10)).to eq 9.360000000000001
-    expect(25.2.percentage_off(5)).to eq 23.939999999999998
-    expect(76.6.percentage_off(40)).to eq 45.959999999999994
+  it "Float#subtract_percent" do
+    expect(1.0.subtract_percent(10)).to eq 0.9
+    expect(10.4.subtract_percent(10)).to eq 9.360000000000001
+    expect(25.2.subtract_percent(5)).to eq 23.939999999999998
+    expect(76.6.subtract_percent(40)).to eq 45.959999999999994
   end
   
-  it "BigDecimal#percentage_off" do
-    expect(12654377184.123123.percentage_off(10)).to eq 11388939465.710812
-    expect(123.129405.percentage_off(25)).to eq 92.34705375
+  it "BigDecimal#subtract_percent" do
+    expect(12654377184.123123.subtract_percent(10)).to eq 11388939465.710812
+    expect(123.129405.subtract_percent(25)).to eq 92.34705375
   end
 
 end


### PR DESCRIPTION
Wondering if this would be something you would be interested in?

Although this is simple maths, I was quite surprised that there was no method to take a percentage off a Fixnum/Float.

So the idea is

```ruby
# num.percentage_off(percent_to_take_off)
50.percentage_off(10)
=> 45.0
```

I'm not sold on the percentage_off name so would be open to change this.