### PR TITLE
Fix Fixnum Bignum issues

### DIFF
--- a/lib/finishing_moves/array.rb
+++ b/lib/finishing_moves/array.rb
@@ -14,7 +14,7 @@ class Array
 
   def to_indexed_hash(starting_key = 0)
     raise ArgumentError, "#{starting_key.inspect} is not an integer" unless starting_key.is_a? Integer
-    to_hash_values(starting_key) { |i| i + 1 }
+    to_hash_values(starting_key)
   end
 
   def to_hash_keys(starting_value = 0, &block)

--- a/lib/finishing_moves/to_bool.rb
+++ b/lib/finishing_moves/to_bool.rb
@@ -6,7 +6,7 @@ class String
   end
 end
 
-class Fixnum
+class Integer
   def to_bool
     return true if self == 1
     return false if self == 0

--- a/spec/numeric_spec.rb
+++ b/spec/numeric_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Numeric methods" do
 
-  it "Fixnum#length" do
+  it "Integer#length" do
     expect(1.length).to eq 1
     expect(5.length).to eq 1
     expect(9.length).to eq 1
@@ -12,9 +12,6 @@ describe "Numeric methods" do
     expect(-9000.length).to eq 4
     # alias
     expect(-9000.digits).to eq 4
-  end
-
-  it "Bignum#length" do
     expect(12356469787881584554556.length).to eq 23
     expect(-12356469787881584554556.length).to eq 23
     # alias
@@ -40,7 +37,7 @@ describe "Numeric methods" do
     expect{ -0.9999999999999062.digits }.to raise_error(ArgumentError)
   end
 
-  it "Fixnum#subtract_percent" do
+  it "Integer#subtract_percent" do
     expect(1.subtract_percent(10)).to eq 0.9
     expect(10.subtract_percent(10)).to eq 9.0
     expect(25.subtract_percent(5)).to eq 23.75
@@ -70,16 +67,13 @@ describe "Numeric methods" do
   end
 
 
-  it "Fixnum#add_percent" do
+  it "Integer#add_percent" do
     expect(1.add_percent(10)).to eq 1.1
     expect(10.add_percent(10)).to eq 11.0
     expect(25.add_percent(5)).to eq 26.25
     expect(76.add_percent(40)).to eq 106.4
     expect(76.markup_by_percent(40)).to eq 106.4
     expect(200.markup_by_percent(100)).to eq 400
-  end
-
-  it "Bignum#add_percent" do
     expect(12356469787881584554556.add_percent(10)).to eq 1.3592116766669745e+22
     expect(12356469787881584554556.markup_by_percent(10)).to eq 1.3592116766669745e+22
   end

--- a/spec/to_bool_spec.rb
+++ b/spec/to_bool_spec.rb
@@ -20,7 +20,7 @@ describe "Boolean typecasting" do
     expect{ "000".to_bool }.to raise_error(ArgumentError)
   end
 
-  it "Fixnum#to_bool" do
+  it "Integer#to_bool" do
     expect(1.to_bool).to eq true
     expect(0.to_bool).to eq false
     expect{ 2.to_bool }.to raise_error(ArgumentError)


### PR DESCRIPTION
This fixes deprecation issues in Ruby 2.4+ it replaces all `Fixnum` and `Bignum` references with `Integer`.